### PR TITLE
add optional parameter "account" for refresh-session API. #21

### DIFF
--- a/dist/ricloud.js
+++ b/dist/ricloud.js
@@ -162,6 +162,11 @@ riCloud.prototype.refreshSession = function(cb) {
   var data = {
     auth_token: this.authToken,
   };
+
+  if (this.account) {
+    data.account = this.account; 
+  }
+
   var options = generateOptions(this, 'refresh_session', data);
 
   function callback(error, response, body) {


### PR DESCRIPTION
#21 

changes
  - [refresh-session]
    - passing icloud account if it's present.